### PR TITLE
Rename gradle publish workflow

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Gradle Build
+name: Gradle Publish
 on:
   release:
     types: [published]


### PR DESCRIPTION
I've noticed that the workflow is still called `Gradle Build` instead of `Gradle Publish`.