### PR TITLE
Include operator details in valid evaluation result

### DIFF
--- a/src/main/java/de/telekom/jsonfilter/operator/EvaluationResult.java
+++ b/src/main/java/de/telekom/jsonfilter/operator/EvaluationResult.java
@@ -66,7 +66,7 @@ public class EvaluationResult {
      * @return EvaluationResult the created evaluation result, which is valid by default.
      */
     public static EvaluationResult valid(Operator op) {
-        return new EvaluationResult(true, op.getOperator().getValue(), null, "", Collections.emptyList());
+        return new EvaluationResult(true, op.getOperator().getValue(), op, "", Collections.emptyList());
     }
 
     /**
@@ -78,19 +78,19 @@ public class EvaluationResult {
      * @return EvaluationResult the created evaluation result, which is valid by default.
      */
     public static EvaluationResult valid(Operator op, List<EvaluationResult> evaluationResults) {
-        return new EvaluationResult(true, op.getOperator().getValue(), null, "", evaluationResults);
+        return new EvaluationResult(true, op.getOperator().getValue(), op, "", evaluationResults);
     }
 
     /**
      * Creates an EvaluationResult instance indicating an error in the evaluation process.
      *
-     * @param rootCause the operator that caused the error.
+     * @param op the operator that caused the error.
      * @param causeDescription the description of the error.
      *
      * @return EvaluationResult the created evaluation result, which is not valid by default.
      */
-    public static EvaluationResult withError(Operator rootCause, String causeDescription) {
-        return new EvaluationResult(false, rootCause.getOperator().getValue(), rootCause, causeDescription, new ArrayList<>());
+    public static EvaluationResult withError(Operator op, String causeDescription) {
+        return new EvaluationResult(false, op.getOperator().getValue(), op, causeDescription, new ArrayList<>());
     }
 
 

--- a/src/main/java/de/telekom/jsonfilter/operator/comparison/ComparisonOperator.java
+++ b/src/main/java/de/telekom/jsonfilter/operator/comparison/ComparisonOperator.java
@@ -43,7 +43,6 @@ public abstract class ComparisonOperator<T> implements Operator {
             case IN -> new InOperator<>(jsonPath, (List<?>) expectedValue);
             case CT -> new ContainsOperator<>(jsonPath, expectedValue);
             case NCT -> new NotContainsOperator<>(jsonPath, expectedValue);
-            default -> null;
         };
     }
 

--- a/src/main/java/de/telekom/jsonfilter/operator/comparison/ComparisonOperatorEnum.java
+++ b/src/main/java/de/telekom/jsonfilter/operator/comparison/ComparisonOperatorEnum.java
@@ -18,7 +18,6 @@ public enum ComparisonOperatorEnum implements OperatorEnum {
     GE("greater or equal"),
     IN("in"),
     CT("contains"),
-    EX("exists"),
     NCT("not contains");
 
     @Getter

--- a/src/main/java/de/telekom/jsonfilter/operator/comparison/ComparisonOperatorEnum.java
+++ b/src/main/java/de/telekom/jsonfilter/operator/comparison/ComparisonOperatorEnum.java
@@ -7,6 +7,7 @@ package de.telekom.jsonfilter.operator.comparison;
 import de.telekom.jsonfilter.operator.OperatorEnum;
 import lombok.Getter;
 
+@Getter
 public enum ComparisonOperatorEnum implements OperatorEnum {
 
     EQ("equal"),
@@ -20,7 +21,6 @@ public enum ComparisonOperatorEnum implements OperatorEnum {
     CT("contains"),
     NCT("not contains");
 
-    @Getter
     private final String value;
 
     ComparisonOperatorEnum(String value) {

--- a/src/main/java/de/telekom/jsonfilter/operator/logic/LogicOperator.java
+++ b/src/main/java/de/telekom/jsonfilter/operator/logic/LogicOperator.java
@@ -34,7 +34,6 @@ public abstract class LogicOperator implements Operator {
         return switch (operator) {
             case AND -> new AndOperator(operatorList);
             case OR -> new OrOperator(operatorList);
-            default -> null;
         };
     }
 }

--- a/src/main/java/de/telekom/jsonfilter/operator/logic/LogicOperator.java
+++ b/src/main/java/de/telekom/jsonfilter/operator/logic/LogicOperator.java
@@ -11,11 +11,9 @@ import lombok.Getter;
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
 public abstract class LogicOperator implements Operator {
-    @Getter
     final LogicOperatorEnum operator;
-
-    @Getter
     List<Operator> operators = new ArrayList<>();
 
     protected LogicOperator(LogicOperatorEnum operator) {


### PR DESCRIPTION
This is needed to improve the filter trace for dropped messages in the UI.